### PR TITLE
Feature: rewrite tracking js domains

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -14,7 +14,7 @@ return [
             'mautic_multidomain_action' => [
                 'path'       => '/multidomain/{objectAction}/{objectId}',
                 'controller' => 'MauticMultiDomainBundle:Multidomain:execute',
-            ],            
+            ],
         ],
     ],
     'menu' => [
@@ -25,7 +25,7 @@ return [
                 'iconClass' => 'fa-globe',
             ],
         ],
-    ],  
+    ],
     'services' => [
         'forms' => [
             'mautic.form.type.multidomain' => [
@@ -75,7 +75,14 @@ return [
                     'router',
                 ],
             ],
+            'mautic.multidomain.subscriber.buildjssubscriber' => [
+                'class'     => \MauticPlugin\MauticMultiDomainBundle\EventListener\BuildJsSubscriber::class,
+                'arguments' => [
+                    'templating.helper.assets',
+                    'request_stack',
+                    'router',
+                ],
+            ],
         ],
-    ], 
-    
+    ],
 ];

--- a/EventListener/BuildJsSubscriber.php
+++ b/EventListener/BuildJsSubscriber.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace MauticPlugin\MauticMultiDomainBundle\EventListener;
+
+use Mautic\CoreBundle\CoreEvents;
+use Mautic\CoreBundle\Event\BuildJsEvent;
+use Mautic\CoreBundle\Templating\Helper\AssetsHelper;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class BuildJsSubscriber implements EventSubscriberInterface
+{
+
+    /**
+     * @var AssetsHelper
+     */
+    private $assetsHelper;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    public function __construct(
+        AssetsHelper $assetsHelper,
+        RequestStack $requestStack,
+        RouterInterface $router
+    ) {
+        $this->assetsHelper   = $assetsHelper;
+        $this->requestStack   = $requestStack;
+        $this->router         = $router;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            CoreEvents::BUILD_MAUTIC_JS => [
+                ['onBuildJs', 9999],
+            ],
+        ];
+    }
+
+    public function onBuildJs(BuildJsEvent $event)
+    {
+        // PageBundle -> $pageTrackingUrl, $pageTrackingCORSUrl, $contactIdUrl
+        $context = $this->router->getContext();
+        $context->setHost($this->requestStack->getCurrentRequest()->getHttpHost());
+        // PageBundle -> $mauticBaseUrl, $jQueryUrl, initGatedVideo
+        $this->assetsHelper->setSiteUrl($this->requestStack->getCurrentRequest()->getSchemeAndHttpHost());
+
+        // The only one we can't control now is DynamicContentBundle -> MauticDomain
+        // however it uses the below, which should mirror where the request was made to - so that's cool.
+        // $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Replaces the tracking domain in your emails based on the sender email address.
 
 The plugin replaces list unsubscribe, image pixel, webview and unsubscribe tokens.
 
+This plugin also rewrites all the tracking javascript domains to the domain from the http request e.g. if your Mautic domain is https://mautic.example.com and tracking js is loaded from from a CNAME, https://trk.example.net all of the domains used inside the tracking javascript will be trk.example.net (rather than mautic.example.com) to avoid the appearance of third-paty requests.
+
 # Installation
 
 * Upload the zip package to your `plugins/`


### PR DESCRIPTION
This PR adds support for replacing the domains used throughout the Mautic core tracking Javascript with the requested domain - current behaviour is a mixture of the request, base_url from settings and host header (via Symfony context) which leads to 2-3 different urls used for client side tracking requests if a CNAME is used. This PR eliminates all those (in stock Mautic 4) and just uses the same host from the request that loads the tracking js for all tracking requests.